### PR TITLE
Fix documentation about how to run in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,18 @@ hamara export --host=localhost:3000 --key=$GRAFANA_API_KEY > datasources.yaml
 cat datasources.yaml
 ```
 
-or using Docker:
+or using Docker (MacOS/Windows):
 
 ```bash
 export GRAFANA_API_KEY=<your API key here>
-docker run --rm trivago/hamara export --host=localhost:3000 --key=$GRAFANA_API_KEY > datasources.yaml
+docker run --rm trivago/hamara ./hamara export --host=host.docker.internal:3000 --key=$GRAFANA_API_KEY > datasources.yaml
+cat datasources.yaml
+```
+
+or using Docker (Linux):
+```bash
+export GRAFANA_API_KEY=<your API key here>
+docker run --add-host host.docker.internal:host-gateway --rm trivago/hamara ./hamara export --host=host.docker.internal:3000 --key=$GRAFANA_API_KEY > datasources.yaml
 cat datasources.yaml
 ```
 


### PR DESCRIPTION
Documentation for running in Docker used localhost:3000 instead of host.docker.internal:3000, which lets docker access grafana on the host machine. Fixes #14  